### PR TITLE
Patch: added missing unit columns and output dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# MIP-River ML
+
+<img width="1505" height="865" alt="image" src="https://github.com/user-attachments/assets/8e7d4cf5-89fe-43e9-aba2-13223cfe521f" />
+
+This repo is meant to hold/store data/documentation related to the inspection of inputs/outputs of the Lynker-Spatial RiverML model (Trained on FEMA-MIP XS). 
+
+## Capability:
+Define and Implement an initial version of an algorithm to generate 3-D channel bathymetric data using RAS cross-sections and other data from the Hydrofabric

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -218,7 +218,10 @@ representive_features <- huc_xs |>
     geom = geom[ceiling(n()/2)],
     source_river_station = source_river_station[ceiling(n()/2)],
     river_station = river_station[ceiling(n()/2)],
-    model = model[ceiling(n()/2)])
+    model = model[ceiling(n()/2)]),
+    metdata_units = metdata_units,
+    epsg = epsg,
+    crs_units = crs_units,
     
 
 nhd_meta <- nhdplusTools::get_vaa(c('ftype', 'streamorde')) |> 
@@ -340,6 +343,6 @@ It was found that the previously used quantile transformation resulted in a gap 
 
 The final input data can be found [here](https://raw.githubusercontent.com/lynker-spatial/mip-riverml/refs/heads/main/data/riverML_ripple_beta_units.parquet)
 
-The final predicted data can be found [here](https://raw.githubusercontent.com/lynker-spatial/mip-riverml/refs/heads/main/data/riverML_ripple_beta_predictions.parquet)
+The final predicted data can be found [here](https://raw.githubusercontent.com/lynker-spatial/mip-riverml/refs/heads/main/data/ripple_ml_bf_generated_tw_y_r.parquet)
 
 The final deployable model can be found [here (with permisions)](https://github.com/lynker-spatial/predict-riverML)

--- a/mip-processing.R
+++ b/mip-processing.R
@@ -1,6 +1,6 @@
 # Define path to FEMA BLE data and output directory
-fema <- '/Users/taddbindas/projects/NGWPC/icefabric/data/mip_full_collection'
-outdir <- '/Users/taddbindas/projects/NGWPC/icefabric/riverML5'
+fema <- './mip_full_collection'
+outdir <- './riverML3'
 dir.create(outdir, showWarnings = FALSE)
 
 library(sf)
@@ -53,7 +53,7 @@ for(b in 1:length(ble)) {
 }
 
 # Reference fabric path
-ref_path <- "/Users/taddbindas/Desktop/sc_reference_fabric.gpkg"
+ref_path <- "./sc_reference_fabric.gpkg"
 
 # Loop through each BLE HUC directory
 for (b in 1:length(ble)) {

--- a/mip-processing.R
+++ b/mip-processing.R
@@ -1,8 +1,16 @@
 # Define path to FEMA BLE data and output directory
-fema <- '/Volumes/MyBook/mip_full_collection/'
-outdir <- glue::glue("{fema}/riverML3")
+fema <- '/Users/taddbindas/projects/NGWPC/icefabric/data/mip_full_collection'
+outdir <- '/Users/taddbindas/projects/NGWPC/icefabric/riverML5'
 dir.create(outdir, showWarnings = FALSE)
 
+library(sf)
+library(dplyr)
+library(glue)
+library(DescTools)
+library(tidyr)
+library(data.table)
+library(purrr)
+library(nhdplusTools)
 
 clean_elev <- function(elev_vec, threshold = 100) {
 for (i in which(elev_vec > threshold)) {
@@ -45,7 +53,7 @@ for(b in 1:length(ble)) {
 }
 
 # Reference fabric path
-ref_path <- "/Users/mikejohnson/hydrofabric/v3.0/reference_fabric.gpkg"
+ref_path <- "/Users/taddbindas/Desktop/sc_reference_fabric.gpkg"
 
 # Loop through each BLE HUC directory
 for (b in 1:length(ble)) {
@@ -163,6 +171,9 @@ for (b in 1:length(ble)) {
           source_river_station = source_river_station[ceiling(n()/2)],
           river_station = river_station[ceiling(n()/2)],
           model = model[ceiling(n()/2)],
+          metdata_units = metdata_units,
+          epsg = epsg,
+          crs_units = crs_units,
         )
       
       # Write output layers
@@ -170,7 +181,7 @@ for (b in 1:length(ble)) {
       write_sf(representive_features, outdir_here, layer = "representative_xs")
       
       read_sf(
-        ref_path, "flowpaths",
+        ref_path, "reference_flowpaths",
         wkt_filter = st_as_text(st_as_sfc(st_bbox(st_union(huc_xs))))
       ) |> 
         write_sf(outdir_here, layer = "reference_fabric")


### PR DESCRIPTION
### Added:
- the following unit columns were missing from the output script. They were re-added back
```r
          metdata_units = metdata_units,
          epsg = epsg,
          crs_units = crs_units,
```
- reran the processing script and updated the parquet file with outputs
- fixed documentation and added paths to RiverML prediction data
